### PR TITLE
Add some useful environment variables to the Chronos task

### DIFF
--- a/src/main/scala/com/airbnb/scheduler/mesos/MesosTaskBuilder.scala
+++ b/src/main/scala/com/airbnb/scheduler/mesos/MesosTaskBuilder.scala
@@ -87,7 +87,13 @@ class MesosTaskBuilder @Inject()(val conf: SchedulerConfiguration) {
         .setName("CHRONOS_JOB_OWNER").setValue(job.owner))
       .addVariables(Variable.newBuilder()
         .setName("CHRONOS_JOB_NAME").setValue(job.name))
-       
+      .addVariables(Variable.newBuilder()
+        .setName("CHRONOS_RSRC_MEM").setValue(job.mem))
+      .addVariables(Variable.newBuilder()
+        .setName("CHRONOS_RSRC_CPU").setValue(job.cpus))
+      .addVariables(Variable.newBuilder()
+        .setName("CHRONOS_RSRC_DISK").setValue(job.disk))
+
     // If the job defines custom environment variables, add them to the builder
     // Don't add them if they already exist to prevent overwriting the defaults
     val builtinEnvNames = environment.getVariablesList().asScala.map(_.getName()).toSet

--- a/src/main/scala/com/airbnb/scheduler/mesos/MesosTaskBuilder.scala
+++ b/src/main/scala/com/airbnb/scheduler/mesos/MesosTaskBuilder.scala
@@ -88,11 +88,11 @@ class MesosTaskBuilder @Inject()(val conf: SchedulerConfiguration) {
       .addVariables(Variable.newBuilder()
         .setName("CHRONOS_JOB_NAME").setValue(job.name))
       .addVariables(Variable.newBuilder()
-        .setName("CHRONOS_RSRC_MEM").setValue(job.mem))
+        .setName("CHRONOS_RSRC_MEM").setValue(job.mem.toString))
       .addVariables(Variable.newBuilder()
-        .setName("CHRONOS_RSRC_CPU").setValue(job.cpus))
+        .setName("CHRONOS_RSRC_CPU").setValue(job.cpus.toString))
       .addVariables(Variable.newBuilder()
-        .setName("CHRONOS_RSRC_DISK").setValue(job.disk))
+        .setName("CHRONOS_RSRC_DISK").setValue(job.disk.toString))
 
     // If the job defines custom environment variables, add them to the builder
     // Don't add them if they already exist to prevent overwriting the defaults


### PR DESCRIPTION
This adds the following environment variables and their purpose

CHRONOS_RSRC_CPU  - The CPU resources allocated to this job
CHRONOS_RSRC_DISK - The disk resources allocated to this job
CHRONOS_RSRC_MEM  - Tme memory resources allocated to this job

The value in these is certain programs (like the JVM) can use these
values to optimize how they run (like setting the -xmx parameter).
Honestly Mesos should do this but I figure it doesn't hurt to put
it here and later have Mesos provide it too.

@mngo87  Please review...
