### PR TITLE
BCK-3639 Adding description and owner name fields to jobs

### DIFF
--- a/src/main/resources/assets/app/scripts/models/base_job.js
+++ b/src/main/resources/assets/app/scripts/models/base_job.js
@@ -26,8 +26,8 @@ function($, Backbone, _, moment, BaseJobValidations) {
   }
 
   BaseWhiteList = [
-    'name', 'command', 'owner', 'async', 'epsilon', 'executor', 'disabled',
-    'cpus', 'mem', 'disk', 'highPriority'
+    'name', 'command', 'description', 'owner', 'ownerName', 'async', 'epsilon', 'executor', 
+    'disabled', 'cpus', 'mem', 'disk', 'highPriority'
   ];
 
   BaseJobModel = Backbone.Model.extend({

--- a/src/main/resources/assets/app/scripts/templates/job_detail_view.hbs
+++ b/src/main/resources/assets/app/scripts/templates/job_detail_view.hbs
@@ -19,7 +19,7 @@
       </div>
       <span class="help-inline hide"></span>
     </div>
-    
+
     <div class="row-fluid control-group job-detail-row job-detail"
          data-toggle="tooltip"
          data-html="true"

--- a/src/main/resources/assets/app/scripts/templates/job_detail_view.hbs
+++ b/src/main/resources/assets/app/scripts/templates/job_detail_view.hbs
@@ -20,7 +20,7 @@
       <span class="help-inline hide"></span>
     </div>
     
-     <div class="row-fluid control-group job-detail-row job-detail"
+    <div class="row-fluid control-group job-detail-row job-detail"
          data-toggle="tooltip"
          data-html="true"
          data-title="Description of the job."
@@ -37,7 +37,7 @@
 
     <div class="row-fluid control-group job-detail-row job-detail"
          data-toggle="tooltip"
-         data-html="true"
+         data-html=" "
          data-title="Command for the executor to run."
          data-placement="bottom">
       <div class="detail">Command</div>
@@ -80,7 +80,7 @@
             <div class="display hightlight owner"
                  data-rv-text="job.owner">{{owner}}</div>
             <div class="field cmd">
-              <input class="job-input" value="{{owner}}" name="owner" tabindex="6"
+              <input class="job-input" value="{{owner}}" name="owner" tabindex="5"
                      data-rv-value="job.owner">
             </div>
             <span class="help-inline hide"></span>
@@ -97,7 +97,7 @@
             <div class="display hightlight owner"
                  data-rv-text="job.ownerName">{{ownerName}}</div>
             <div class="field cmd">
-              <input class="job-input" value="{{ownerName}}" name="ownerName" tabindex="7"
+              <input class="job-input" value="{{ownerName}}" name="ownerName" tabindex="6"
                      data-rv-value="job.ownerName">
             </div>
             <span class="help-inline hide"></span>
@@ -237,7 +237,7 @@
                      value="{{executor}}"
                      name="executor"
                      placeholder="/custom/executor"
-                     tabindex="5">
+                     tabindex="7">
             </div>
           </div>
         </div>

--- a/src/main/resources/assets/app/scripts/templates/job_detail_view.hbs
+++ b/src/main/resources/assets/app/scripts/templates/job_detail_view.hbs
@@ -19,6 +19,21 @@
       </div>
       <span class="help-inline hide"></span>
     </div>
+    
+     <div class="row-fluid control-group job-detail-row job-detail"
+         data-toggle="tooltip"
+         data-html="true"
+         data-title="Description of the job."
+         data-placement="bottom">
+      <div class="detail">Description</div>
+      <div class="display hightlight description"
+           data-rv-text="job.description">{{description}}</div>
+      <div class="field cmd">
+        <input class="job-input" value="{{description}}"
+               data-rv-value="job.description" name="description" tabindex="2">
+      </div>
+      <span class="help-inline hide"></span>
+    </div>
 
     <div class="row-fluid control-group job-detail-row job-detail"
          data-toggle="tooltip"
@@ -30,7 +45,7 @@
            data-rv-text="job.command">{{command}}</div>
       <div class="field cmd">
         <input class="job-input" value="{{command}}"
-               data-rv-value="job.command" name="command" tabindex="2">
+               data-rv-value="job.command" name="command" tabindex="3">
       </div>
       <span class="help-inline hide"></span>
     </div>
@@ -47,7 +62,7 @@
                  data-placeholder="Choose parents..."
                  name="parents"
                  type="hidden"
-                 tabindex="3">
+                 tabindex="4">
         </div>
         <span class="help-inline hide"></span>
       </div>
@@ -55,20 +70,40 @@
 
     <div class="row-fluid job-detail-row">
       <div class="span6">
-        <div class="control-group job-detail"
-             data-toggle="tooltip"
-             data-title="Owner's email address(es)<br>The owner(s) will be emailed in the event of a job failure or disruption."
-             data-html="true"
-             data-placement="bottom">
-          <div class="detail">Owner(s)</div>
-          <div class="display hightlight owner"
-               data-rv-text="job.owner">{{owner}}</div>
-          <div class="field cmd">
-            <input class="job-input" value="{{owner}}" name="owner" tabindex="4"
-                   data-rv-value="job.owner">
+        <div class="row-fluid">
+          <div class="control-group job-detail"
+               data-toggle="tooltip"
+               data-title="Owner's email address(es)<br>The owner(s) will be emailed in the event of a job failure or disruption."
+               data-html="true"
+               data-placement="bottom">
+            <div class="detail">Owner(s)</div>
+            <div class="display hightlight owner"
+                 data-rv-text="job.owner">{{owner}}</div>
+            <div class="field cmd">
+              <input class="job-input" value="{{owner}}" name="owner" tabindex="6"
+                     data-rv-value="job.owner">
+            </div>
+            <span class="help-inline hide"></span>
           </div>
-          <span class="help-inline hide"></span>
         </div>
+
+        <div class="row-fluid">
+          <div class="control-group job-detail"
+               data-toggle="tooltip"
+               data-title="Owner's name."
+               data-html="true"
+               data-placement="bottom">
+            <div class="detail">Owner Name</div>
+            <div class="display hightlight owner"
+                 data-rv-text="job.ownerName">{{ownerName}}</div>
+            <div class="field cmd">
+              <input class="job-input" value="{{ownerName}}" name="ownerName" tabindex="7"
+                     data-rv-value="job.ownerName">
+            </div>
+            <span class="help-inline hide"></span>
+          </div>
+        </div>
+
       </div>
 
       {{#persisted}}
@@ -126,7 +161,7 @@
            data-rv-text="job.schedule">{{schedule}}</div>
       <div class="field cmd small-input repeats control-group">
         <label for="repeats" class="control-label">R</label>
-        <input class="job-input" value="{{repeats}}" name="repeats" tabindex="6"
+        <input class="job-input" value="{{repeats}}" name="repeats" tabindex="8"
          data-rv-value="job.repeats"
          placeholder="∞" data-placeholder="∞"
          data-title="Number of Repetitions<br>Blank for Infinite (∞), 0 for none."
@@ -139,7 +174,7 @@
       <div class="field cmd small-input control-group">
         <input class="job-input datepicker" value="{{startDate}}"
           data-rv-value="job.startDate"
-          name="startDate" tabindex="7"
+          name="startDate" tabindex="9"
           data-title="Date to start the job."
           data-toggle="tooltip">
       </div>
@@ -147,7 +182,7 @@
       <div class="small-input break">T</div>
 
       <div class="field cmd small-input bootstrap-timepicker control-group">
-        <input class="job-input timepicker" value="{{startTime}}" name="startTime" tabindex="8"
+        <input class="job-input timepicker" value="{{startTime}}" name="startTime" tabindex="10"
           data-rv-value="job.startTime"
           data-title="Time to start the job."
           data-toggle="tooltip"
@@ -161,7 +196,7 @@
 
       <div class="field cmd small-input period control-group">
         <label for="duration" class="control-label">P</label>
-        <input class="job-input" value="{{duration}}" name="duration" tabindex="9"
+        <input class="job-input" value="{{duration}}" name="duration" tabindex="11"
           data-rv-value="job.duration"
           data-title="Duration<br>The job will execute at every passing of duration from start time."
           data-html="true"
@@ -212,7 +247,7 @@
           <div class="detail">Epsilon</div>
           <div class="display highlight cmd epsilon">{{epsilon}}</div>
           <div class="field cmd epsilon control-group">
-            <input class="job-input" value="{{epsilon}}" name="epsilon" tabindex="10"
+            <input class="job-input" value="{{epsilon}}" name="epsilon" tabindex="12"
               title="Amount of time after a failure within which to retry the job."
               data-rv-value="job.epsilon"
               data-container=".job-{{cid}}"

--- a/src/main/scala/com/airbnb/scheduler/jobs/Jobs.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/Jobs.scala
@@ -31,6 +31,8 @@ trait BaseJob {
   def executorFlags: String = ""
   def retries: Int = 2
   def owner: String = ""
+  def ownerName: String = ""
+  def description: String = ""
   def lastSuccess: String = ""
   def lastError: String = ""
   def async: Boolean = false
@@ -60,6 +62,8 @@ case class ScheduleBasedJob(
     @JsonProperty override val executorFlags: String = "",
     @JsonProperty override val retries: Int = 2,
     @JsonProperty override val owner: String = "",
+    @JsonProperty override val ownerName: String = "",
+    @JsonProperty override val description: String = "",
     @JsonProperty override val lastSuccess: String = "",
     @JsonProperty override val lastError: String = "",
     @JsonProperty override val async: Boolean = false,
@@ -91,6 +95,8 @@ case class DependencyBasedJob(
     @JsonProperty override val executorFlags: String = "",
     @JsonProperty override val retries: Int = 2,
     @JsonProperty override val owner: String = "",
+    @JsonProperty override val ownerName: String = "",
+    @JsonProperty override val description: String = "",
     @JsonProperty override val lastSuccess: String = "",
     @JsonProperty override val lastError: String = "",
     @JsonProperty override val async: Boolean = false,

--- a/src/main/scala/com/airbnb/utils/JobDeserializer.scala
+++ b/src/main/scala/com/airbnb/utils/JobDeserializer.scala
@@ -49,6 +49,14 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
     val owner =
       if (node.has("owner") && node.get("owner") != null) node.get("owner").asText
       else ""
+        
+    val ownerName =
+      if (node.has("ownerName") && node.get("ownerName") != null) node.get("ownerName").asText
+      else ""
+        
+    val description =
+      if (node.has("description") && node.get("description") != null) node.get("description").asText
+      else ""
 
     val async =
       if (node.has("async") && node.get("async") != null) node.get("async").asBoolean
@@ -158,8 +166,9 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
       }
       new DependencyBasedJob(parents = parentList.toSet,
         name = name, command = command, epsilon = epsilon, successCount = successCount, errorCount = errorCount,
-        executor = executor, executorFlags = executorFlags, retries = retries, owner = owner, lastError = lastError,
-        lastSuccess = lastSuccess, async = async, cpus = cpus, disk = disk, mem = mem, disabled = disabled,
+        executor = executor, executorFlags = executorFlags, retries = retries, owner = owner, 
+        ownerName = ownerName, description = description, lastError = lastError, lastSuccess = lastSuccess, 
+        async = async, cpus = cpus, disk = disk, mem = mem, disabled = disabled,
         errorsSinceLastSuccess = errorsSinceLastSuccess, uris = uris, highPriority = highPriority,
         runAsUser = runAsUser, container = container, environmentVariables = environmentVariables, shell = shell,
         arguments = arguments)
@@ -167,8 +176,9 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
         val scheduleTimeZone = if (node.has("scheduleTimeZone")) node.get("scheduleTimeZone").asText else ""
         new ScheduleBasedJob(node.get("schedule").asText, name = name, command = command,
         epsilon = epsilon, successCount = successCount, errorCount = errorCount, executor = executor,
-        executorFlags = executorFlags, retries = retries, owner = owner, lastError = lastError,
-        lastSuccess = lastSuccess, async = async, cpus = cpus, disk = disk, mem = mem, disabled = disabled,
+        executorFlags = executorFlags, retries = retries, owner = owner, ownerName = ownerName, 
+        description = description, lastError = lastError, lastSuccess = lastSuccess, async = async,
+        cpus = cpus, disk = disk, mem = mem, disabled = disabled,
         errorsSinceLastSuccess = errorsSinceLastSuccess, uris = uris,  highPriority = highPriority,
         runAsUser = runAsUser, container = container, scheduleTimeZone = scheduleTimeZone,
         environmentVariables = environmentVariables, shell = shell, arguments = arguments)
@@ -176,8 +186,9 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
       /* schedule now */
       new ScheduleBasedJob("R1//PT24H", name = name, command = command, epsilon = epsilon, successCount = successCount,
         errorCount = errorCount, executor = executor, executorFlags = executorFlags, retries = retries, owner = owner,
-        lastError = lastError, lastSuccess = lastSuccess, async = async, cpus = cpus, disk = disk, mem = mem,
-        disabled = disabled, errorsSinceLastSuccess = errorsSinceLastSuccess, uris = uris,  highPriority = highPriority,
+        ownerName = ownerName, description = description, lastError = lastError, lastSuccess = lastSuccess, 
+        async = async, cpus = cpus, disk = disk, mem = mem, disabled = disabled, 
+        errorsSinceLastSuccess = errorsSinceLastSuccess, uris = uris,  highPriority = highPriority,
         runAsUser = runAsUser, container = container, environmentVariables = environmentVariables, shell = shell,
         arguments = arguments)
     }

--- a/src/main/scala/com/airbnb/utils/JobSerializer.scala
+++ b/src/main/scala/com/airbnb/utils/JobSerializer.scala
@@ -35,6 +35,12 @@ class JobSerializer extends JsonSerializer[BaseJob] {
 
     json.writeFieldName("owner")
     json.writeString(baseJob.owner)
+    
+    json.writeFieldName("ownerName")
+    json.writeString(baseJob.ownerName)
+    
+    json.writeFieldName("description")
+    json.writeString(baseJob.description)
 
     json.writeFieldName("async")
     json.writeBoolean(baseJob.async)

--- a/src/test/scala/com/airbnb/scheduler/api/SerDeTest.scala
+++ b/src/test/scala/com/airbnb/scheduler/api/SerDeTest.scala
@@ -42,8 +42,9 @@ class SerDeTest extends SpecificationWithJUnit {
       )
       
       val a = new DependencyBasedJob(Set("B", "C", "D", "E"), "A", "noop", Minutes.minutes(5).toPeriod, 10L,
-        20L, "fooexec", "fooflags", 7, "foo@bar.com", "TODAY", "YESTERDAY", true, container = container,
-        environmentVariables = environmentVariables, shell = false, arguments = arguments)
+        20L, "fooexec", "fooflags", 7, "foo@bar.com", "Foo", "Test dependency-based job", "TODAY", 
+        "YESTERDAY", true, container = container, environmentVariables = environmentVariables, 
+        shell = false, arguments = arguments)
 
       val aStr = objectMapper.writeValueAsString(a)
       val aCopy = objectMapper.readValue(aStr, classOf[DependencyBasedJob])
@@ -75,8 +76,9 @@ class SerDeTest extends SpecificationWithJUnit {
       )
       
       val a = new ScheduleBasedJob("FOO/BAR/BAM", "A", "noop", Minutes.minutes(5).toPeriod, 10L, 20L,
-        "fooexec", "fooflags", 7, "foo@bar.com", "TODAY", "YESTERDAY", true, container = container,
-        environmentVariables = environmentVariables, shell = true, arguments = arguments)
+        "fooexec", "fooflags", 7, "foo@bar.com", "Foo", "Test schedule-based job", "TODAY", 
+        "YESTERDAY", true, container = container, environmentVariables = environmentVariables, 
+        shell = true, arguments = arguments)
 
       val aStr = objectMapper.writeValueAsString(a)
       val aCopy = objectMapper.readValue(aStr, classOf[ScheduleBasedJob])


### PR DESCRIPTION
This commit adds backend support for description and job owner name fields, plus support for viewing and editing these fields via the Chronos web UI. Changes have been tested via an AWS Chronos instance.
